### PR TITLE
Add undo actions

### DIFF
--- a/apps/okreads-e2e/src/specs/reading-list.spec.ts
+++ b/apps/okreads-e2e/src/specs/reading-list.spec.ts
@@ -1,12 +1,14 @@
-import { $, browser, ExpectedConditions } from 'protractor';
+import { $, $$, browser, ExpectedConditions, element, by } from 'protractor';
 
 describe('When: I use the reading list feature', () => {
-  it('Then: I should see my reading list', async () => {
+  beforeEach(async () => {
     await browser.get('/');
     await browser.wait(
       ExpectedConditions.textToBePresentInElement($('tmo-root'), 'okreads')
     );
+  });
 
+  it('Then: I should see my reading list', async () => {
     const readingListToggle = await $('[data-testing="toggle-reading-list"]');
     await readingListToggle.click();
 
@@ -16,5 +18,33 @@ describe('When: I use the reading list feature', () => {
         'My Reading List'
       )
     );
+  });
+
+  it('Then: undo removing book should add it list', async () => {
+    const readingListToggle = await $('[data-testing="toggle-reading-list"]');
+    await readingListToggle.click();
+    await element.all(by.css('[data-testing="remove-list-item"]')).each((button) => {
+      button.click();
+    });
+    await $('[data-testing="close-reading-list"]').click();
+
+    const form = await $('form');
+    const input = await $('input[type="search"]');
+    await input.sendKeys('ngrx');
+    await form.submit();
+
+    const addToReadingListBtn = element.all(by.css('[data-testing="add-to-reading-list"]')).first();
+    await addToReadingListBtn.click();
+
+    await readingListToggle.click();
+    const readingListCount = $$('[data-testing="reading-list-item"]').count();
+    await element(by.css('[data-testing="remove-list-item"]')).click();
+
+    await browser.executeScript("return await document.querySelector('.mat-simple-snackbar-action')").
+    then((undoButton: HTMLElement)=>{
+      undoButton.click();
+    });
+    const newCount = $$('[data-testing="reading-list-item"]').count();
+    expect(newCount).toEqual(readingListCount);
   });
 });

--- a/apps/okreads/browser/src/app/app.component.html
+++ b/apps/okreads/browser/src/app/app.component.html
@@ -24,7 +24,7 @@
     <div class="reading-list-container" data-testing="reading-list-container">
       <h2>
         My Reading List
-        <button mat-icon-button aria-label="Close Reading List" (click)="drawer.close()">
+        <button data-testing="close-reading-list" mat-icon-button aria-label="Close Reading List" (click)="drawer.close()">
           <mat-icon>close</mat-icon>
         </button>
       </h2>

--- a/libs/books/data-access/src/lib/+state/reading-list.effects.spec.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.effects.spec.ts
@@ -3,6 +3,7 @@ import { ReplaySubject } from 'rxjs';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { SharedTestingModule } from '@tmo/shared/testing';
 import { ReadingListEffects } from './reading-list.effects';
@@ -19,7 +20,8 @@ describe('ToReadEffects', () => {
       providers: [
         ReadingListEffects,
         provideMockActions(() => actions),
-        provideMockStore()
+        provideMockStore(),
+        { provide: MatSnackBar}
       ]
     });
 

--- a/libs/books/feature/src/lib/book-search/book-search.component.html
+++ b/libs/books/feature/src/lib/book-search/book-search.component.html
@@ -33,6 +33,7 @@
           <div>
             <button
               mat-flat-button
+              [attr.data-testing]="book.isAdded ? '' : 'add-to-reading-list'"
               color="primary"
               (click)="addBookToReadingList(book)"
               [disabled]="book.isAdded"

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.html
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="(readingList$ | async).length > 0; else empty">
-  <section class="reading-list-item" *ngFor="let readingItem of readingList$ | async">
+  <section data-testing="reading-list-item" class="reading-list-item" *ngFor="let readingItem of readingList$ | async">
     <div>
       <img class="reading-list-item--cover" [src]="readingItem.coverUrl" alt="" />
     </div>
@@ -12,6 +12,7 @@
     <div>
       <button
         mat-icon-button
+        data-testing="remove-list-item"
         color="warn"
         [attr.aria-label]="'Remove ' + readingItem.title + ' from reading list'"
         (click)="removeFromReadingList(readingItem)"

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.ts
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.ts
@@ -1,6 +1,9 @@
 import { Component } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { getReadingList, removeFromReadingList } from '@tmo/books/data-access';
+import {
+  getReadingList,
+  removeFromReadingList
+} from '@tmo/books/data-access';
 
 @Component({
   selector: 'tmo-reading-list',
@@ -10,7 +13,9 @@ import { getReadingList, removeFromReadingList } from '@tmo/books/data-access';
 export class ReadingListComponent {
   readingList$ = this.store.select(getReadingList);
 
-  constructor(private readonly store: Store) {}
+  constructor(
+    private readonly store: Store
+  ) {}
 
   removeFromReadingList(item) {
     this.store.dispatch(removeFromReadingList({ item }));


### PR DESCRIPTION
Using MatSnackBar service displaying notifications for user after Add to list or Remove from list actions along with Undo action feature.
1) Added two new actions undoAddToReadingList and undoRemoveFromReadingList 
2) For creating reducer functions grouped undoAddToReadingList with failedAddToReadingList as both are similar. Grouped undoRemoveFromReadingList with failedRemoveFromReadingList in the same manner.
3) Created effects for undoAddToReadingList and undoRemoveFromReadingList actions
4) Created e2e test case to test the undo action of adding book to list

Demo of undo actions of add to list and remove from list: https://recordit.co/Vdf9WLyNbz

<img width="1610" alt="Screen Shot 2020-09-30 at 1 15 51 PM" src="https://user-images.githubusercontent.com/19898265/94723918-19674580-031f-11eb-8473-05131e8e6bae.png">

<img width="1612" alt="Screen Shot 2020-09-30 at 12 57 36 PM" src="https://user-images.githubusercontent.com/19898265/94723938-1ff5bd00-031f-11eb-87ce-77497eb613ad.png">

